### PR TITLE
Use 'require' instead of using 'fs.readFileSync'

### DIFF
--- a/lib/requester.js
+++ b/lib/requester.js
@@ -4,7 +4,7 @@ var path = require("path");
 var qs    = require('querystring');
 var OAuth = require('oauth').OAuth;
 
-var DRIVER_VERSION = JSON.parse(fs.readFileSync(path.join(__dirname, "../package.json"), 'utf8')).version;
+var DRIVER_VERSION = require('../package.json').version;
 var FACTUAL_API_BASE_URI = 'http://api.v3.factual.com';
 var DRIVER_HEADER = 'factual-nodejs-driver-' + DRIVER_VERSION;
 


### PR DESCRIPTION
Use 'require' instead of using 'fs.readFileSync' #7

browserify doesn't support file system api. so i choose use require way load json as a javascript object and then get the version value of it.